### PR TITLE
Add a dynamic key capability based on 'result'

### DIFF
--- a/servant-github-webhook.cabal
+++ b/servant-github-webhook.cabal
@@ -46,6 +46,7 @@ library
     cryptonite >=0.23,
     github >=0.15,
     http-types >=0.9,
+    unordered-containers >= 0.2,
     memory >=0.14,
     servant >=0.11,
     servant-server >=0.11,
@@ -82,5 +83,22 @@ test-suite singlekey
     bytestring,
     servant-server,
     servant-github-webhook,
+    wai,
+    warp
+
+test-suite dynamickey
+  type:                exitcode-stdio-1.0
+  ghc-options:
+    -Wall
+  hs-source-dirs:      test/dynamickey
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:
+    aeson,
+    base,
+    bytestring,
+    servant-server,
+    servant-github-webhook,
+    text,
     wai,
     warp

--- a/test/dynamickey/Main.hs
+++ b/test/dynamickey/Main.hs
@@ -4,12 +4,14 @@
 
 import Control.Monad.IO.Class ( liftIO )
 import Data.Aeson ( Object )
+import Data.Monoid
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
 import Servant
 import Servant.GitHub.Webhook
 import Network.Wai ( Application )
 import Network.Wai.Handler.Warp ( run )
+import qualified Data.Text.Encoding as T
 
 main :: IO ()
 main = pure ()
@@ -17,7 +19,7 @@ main = pure ()
 realMain :: IO ()
 realMain = do
   [key, _] <- C8.lines <$> BS.readFile "test/test-keys"
-  run 8080 (app (gitHubKey $ pure key))
+  run 8080 (app (repositoryKey $ \user -> pure $ Just (T.encodeUtf8 user <> key)))
 
 app :: GitHubKey Object -> Application
 app key

--- a/test/multikey/Main.hs
+++ b/test/multikey/Main.hs
@@ -60,16 +60,16 @@ type WebhookApi
       :> GitHubSignedReqBody' 'Repo2 '[JSON] Object
       :> Post '[JSON] ()
 
-type MyGitHubKey = GitHubKey' Key
+type MyGitHubKey = GitHubKey' Key Object
 
 data Key
   = Repo1
   | Repo2
 
 constKeys :: BS.ByteString -> BS.ByteString -> MyGitHubKey
-constKeys k1 k2 = GitHubKey $ \k -> pure $ case k of
-  Repo1 -> k1
-  Repo2 -> k2
+constKeys k1 k2 = GitHubKey $ \k _ -> pure $ case k of
+  Repo1 -> Just k1
+  Repo2 -> Just k2
 
 type instance Demote' ('KProxy :: KProxy Key) = Key
 instance Reflect 'Repo1 where


### PR DESCRIPTION
Some uses of webhooks require dynamic keys, such as adding new keys for
new users or repositories.  This change allows dynamic keys to look at
the result (ex: repository or username) before returning a key for use
in verification.  N.B. the API changes since we now have:

Another type variable on GitHubKey'.
GitHubKey now wraps a function that takes an extra argument.
Helper functions of `dynamicKey` and `repositoryKey` exist.
Helper class of `HasRepository` exists with bare-bones instances.