### PR TITLE
Feature/GitHub webhooks instances

### DIFF
--- a/servant-github-webhook.cabal
+++ b/servant-github-webhook.cabal
@@ -45,6 +45,7 @@ library
     bytestring >= 0.10,
     cryptonite >=0.23,
     github >=0.15,
+    github-webhooks >=0.9,
     http-types >=0.9,
     unordered-containers >= 0.2,
     memory >=0.14,

--- a/servant-github-webhook.cabal
+++ b/servant-github-webhook.cabal
@@ -46,6 +46,7 @@ library
     cryptonite >=0.23,
     github >=0.15,
     http-types >=0.9,
+    unordered-containers >= 0.2,
     memory >=0.14,
     servant >=0.11,
     servant-server >=0.11,
@@ -82,5 +83,22 @@ test-suite singlekey
     bytestring,
     servant-server,
     servant-github-webhook,
+    wai,
+    warp
+
+test-suite dynamickey
+  type:                exitcode-stdio-1.0
+  ghc-options:
+    -Wall
+  hs-source-dirs:      test/dynamickey
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:
+    aeson,
+    base,
+    bytestring,
+    servant-server,
+    servant-github-webhook,
+    text,
     wai,
     warp

--- a/src/Servant/GitHub/Webhook.hs
+++ b/src/Servant/GitHub/Webhook.hs
@@ -96,6 +96,7 @@ import Control.Monad.IO.Class ( liftIO )
 import Crypto.Hash.Algorithms ( SHA1 )
 import Crypto.MAC.HMAC ( hmac, HMAC(..) )
 import Data.Aeson ( decode', encode, Value(String, Object) )
+import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as AesonType
 import Data.ByteArray ( convert, constEq )
 import qualified Data.Text as T
@@ -242,6 +243,9 @@ instance HasRepository AesonType.Object where
 -- handler (eventOf -> e) = -- ... expr handling e :: IssuesEvent ...
 -- @
 newtype EventWithHookRepo e = EventWithHookRepo { eventOf :: e }
+
+instance Aeson.FromJSON e => Aeson.FromJSON (EventWithHookRepo e) where
+    parseJSON o = EventWithHookRepo <$> Aeson.parseJSON o
 
 instance EventHasRepo e => HasRepository (EventWithHookRepo e) where
     getFullName = Just . whRepoFullName . repoForEvent . eventOf

--- a/src/Servant/GitHub/Webhook.hs
+++ b/src/Servant/GitHub/Webhook.hs
@@ -66,6 +66,7 @@ module Servant.GitHub.Webhook
 , gitHubKey
 , dynamicKey
 , repositoryKey, HasRepository
+, EventWithHookRepo(..)
 
   -- * Reexports
   --

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
 resolver: lts-10.0
+extra-deps:
+    - git: https://github.com/onrock-eng/github-webhooks
+      commit: 9d5bf07029ed99fca5e53123c7a9c8a8af9819bc

--- a/test/dynamickey/Main.hs
+++ b/test/dynamickey/Main.hs
@@ -4,12 +4,14 @@
 
 import Control.Monad.IO.Class ( liftIO )
 import Data.Aeson ( Object )
+import Data.Monoid
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C8
 import Servant
 import Servant.GitHub.Webhook
 import Network.Wai ( Application )
 import Network.Wai.Handler.Warp ( run )
+import qualified Data.Text.Encoding as T
 
 main :: IO ()
 main = pure ()
@@ -17,7 +19,7 @@ main = pure ()
 realMain :: IO ()
 realMain = do
   [key, _] <- C8.lines <$> BS.readFile "test/test-keys"
-  run 8080 (app (gitHubKey $ pure key))
+  run 8080 (app (repositoryKey $ \user -> pure $ Just (T.encodeUtf8 user <> key)))
 
 app :: GitHubKey Object -> Application
 app key

--- a/test/multikey/Main.hs
+++ b/test/multikey/Main.hs
@@ -60,16 +60,16 @@ type WebhookApi
       :> GitHubSignedReqBody' 'Repo2 '[JSON] Object
       :> Post '[JSON] ()
 
-type MyGitHubKey = GitHubKey' Key
+type MyGitHubKey = GitHubKey' Key Object
 
 data Key
   = Repo1
   | Repo2
 
 constKeys :: BS.ByteString -> BS.ByteString -> MyGitHubKey
-constKeys k1 k2 = GitHubKey $ \k -> pure $ case k of
-  Repo1 -> k1
-  Repo2 -> k2
+constKeys k1 k2 = GitHubKey $ \k _ -> pure $ case k of
+  Repo1 -> Just k1
+  Repo2 -> Just k2
 
 type instance Demote' ('KProxy :: KProxy Key) = Key
 instance Reflect 'Repo1 where


### PR DESCRIPTION
As mentioned in PR #7 we might want to incorporate github-webhooks (package) and instances for HasRepository.  That's this PR.

I did the cheap thing and made one instances of the `HasRepository` class on a polymorphic newtype wrapper and re-used github-webhooks' `EventHasRepo` class.  The advantage here is lower maintenance - we didn't need to write and maintain N instances. The downside is the user needs to unwrap the Events (but the JSON decoding should be handled).  It would be nice to just re-use `EventHasRepo` and not have our own class but that would assume all users stick with the github-webhooks types which seems overly-restrictive.