### PR TITLE
Add Reflect instances for Installation events

### DIFF
--- a/src/Servant/GitHub/Webhook.hs
+++ b/src/Servant/GitHub/Webhook.hs
@@ -232,7 +232,7 @@ instance HasRepository AesonType.Object where
 -- |For use with 'github-webhooks' package types.  Routes would look like:
 --
 -- @
---      api = "github-webevent" :> 
+--      api = "github-webevent" :>
 --          :> GitHubSignedReqBody '[JSON] (EventWithHookRepo IssuesEvent)
 --          :> Post '[JSON] ()
 -- @
@@ -422,6 +422,12 @@ instance Reflect 'WebhookForkEvent where
 
 instance Reflect 'WebhookGollumEvent where
   reflect _ = WebhookGollumEvent
+
+instance Reflect 'WebhookInstallationEvent where
+  reflect _ = WebhookInstallationEvent
+
+instance Reflect 'WebhookInstallationRepositoriesEvent where
+  reflect _ = WebhookInstallationRepositoriesEvent
 
 instance Reflect 'WebhookIssueCommentEvent where
   reflect _ = WebhookIssueCommentEvent

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
-resolver: nightly-2018-04-05
+resolver: lts-14.1
+
+extra-deps:
+  - github-0.22
+  - binary-instances-1


### PR DESCRIPTION
This PR adds `Reflect` instances required to handle GitHub App installation events.

I've also updated `stack.yaml` to use a newer LTS resolver.