### PR TITLE
Add instance reflect for repository events

### DIFF
--- a/src/Servant/GitHub/Webhook.hs
+++ b/src/Servant/GitHub/Webhook.hs
@@ -426,6 +426,9 @@ instance Reflect 'WebhookGollumEvent where
 instance Reflect 'WebhookInstallationEvent where
   reflect _ = WebhookInstallationEvent
 
+instance Reflect 'WebhookRepositoryEvent where
+  reflect _ = WebhookRepositoryEvent
+
 instance Reflect 'WebhookInstallationRepositoriesEvent where
   reflect _ = WebhookInstallationRepositoriesEvent
 


### PR DESCRIPTION
Repo events didn't have a reflect instance... now they do.