### PR TITLE
current upper bounds on `base` and `aeson`

### DIFF
--- a/servant-github-webhook.cabal
+++ b/servant-github-webhook.cabal
@@ -39,8 +39,8 @@ library
   ghc-options:
     -Wall
   build-depends:
-    base ==4.*,
-    aeson >=0.11,
+    base ==4.* && <4.16,
+    aeson >=0.11 && <2,
     base16-bytestring >=0.1,
     bytestring >= 0.10,
     cryptonite >=0.19,


### PR DESCRIPTION
`cabal build all --enable-tests` succeeds with GHC 9.0 and `aeson` < 2

It fails with GHC 9.2+ and/or `aeson` >= 2

https://github.com/tsani/servant-github-webhook/issues/19